### PR TITLE
Replace system-storage-manager with lvm2 in centos

### DIFF
--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -1,7 +1,7 @@
 ---
 - name: centos | installing lvm2
   yum:
-    name: system-storage-manager
+    name: lvm2
     state: present
 
 - name: centos | installing sg3_utils


### PR DESCRIPTION
Fixes #2 

Tested this change successfully on a fresh Centos 6 and Centos 7 VM.
