### PR TITLE
Add opts and mopts support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ lvm_groups: []
   #       # Define size of lvol
   #       # 100%FREE, 10g, 1024 (megabytes by default)
   #       size: 5g
+  #       # Defines additional lvcreate options (e.g. stripes, stripesize, etc)
+  #       opts: ''
   #       # Defines if lvol should exist or be removed
   #       # true or false
   #       create: true
@@ -42,6 +44,8 @@ lvm_groups: []
   #       mount: false
   #       # Defines mountpoint for lvol
   #       mntp: []
+  #       # Defines additional mount options (e.g. noatime, noexec, etc)
+  #       mopts: ''
   #     - lvname: root
   #       size: 40g
   #       create: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,8 @@ lvm_groups: []
   #       # Define size of lvol
   #       # 100%FREE, 10g, 1024 (megabytes by default)
   #       size: 5g
+  #       # Defines additional lvcreate options (e.g. stripes, stripesize, etc)
+  #       opts: ''
   #       # Defines if lvol should exist or be removed
   #       # true or false
   #       create: true
@@ -23,6 +25,8 @@ lvm_groups: []
   #       mount: false
   #       # Defines mountpoint for lvol
   #       mntp: []
+  #       # Defines additional mount options (e.g. noatime, noexec, etc)
+  #       mopts: ''
   #     - lvname: root
   #       size: 40g
   #       create: true

--- a/tasks/manage_lvm.yml
+++ b/tasks/manage_lvm.yml
@@ -16,6 +16,7 @@
     lv: "{{ item[1]['lvname'] }}"
     size: "{{ item[1]['size'] }}"
     shrink: no
+    opts: "{{ item[1]['opts'] | default('') }}"
     state: "present"
   become: true
   register: lvm
@@ -53,6 +54,7 @@
     src: "/dev/{{ item[0]['vgname'] }}/{{ item[1]['lvname'] }}"
     fstype: "{{ item[1]['filesystem'] }}"
     state: "mounted"
+    opts: "{{ item[1]['mopts'] | default('defaults') }}"
   become: true
   with_subelements:
     - "{{ lvm_groups }}"


### PR DESCRIPTION
I propose to add two new fields to `lvname` dictionary:
- `opts`, for passing extra options to `lvcreate`. It can be used e.g. to create stripped LVM volumes with the option `-i num_stripes`.
- `mopts`, for establishing options to the `mount` command. It can be used e.g. to establish options such `noatime`, `noexec`, etc.