### PR TITLE
Support not formatting volumes.

### DIFF
--- a/tasks/manage_lvm.yml
+++ b/tasks/manage_lvm.yml
@@ -80,8 +80,8 @@
   when: >
         lvm['changed'] and
         item[1]['filesystem'] is defined and
-         item[1]['filesystem'] != "None" and
-         item[1]['filesystem'] != "swap" and
+        item[1]['filesystem'] != "None" and
+        item[1]['filesystem'] != "swap" and
         item[1]['filesystem'] != "xfs" and
         item[1]['filesystem'] != "btrfs"
 

--- a/tasks/manage_lvm.yml
+++ b/tasks/manage_lvm.yml
@@ -46,7 +46,9 @@
         (item[1] is defined and
         item[1] != 'None') and
         (item[1]['create'] is defined and
-        item[1]['create']))
+        item[1]['create']) and
+        (item[1]['filesystem'] is defined and
+        item[1]['filesystem'] != 'None'))
 
 - name: manage_lvm | mounting new filesystem(s)
   mount:
@@ -77,6 +79,7 @@
     - lvnames
   when: >
         lvm['changed'] and
+        item[1]['filesystem'] is defined and
         item[1]['filesystem'] != "swap" and
         item[1]['filesystem'] != "xfs" and
         item[1]['filesystem'] != "btrfs"
@@ -89,6 +92,7 @@
     - lvnames
   when: >
         lvm['changed'] and
+        item[1]['filesystem'] is defined and
         item[1]['filesystem'] == "xfs"
 
 - name: manage_lvm | resizing swap
@@ -99,6 +103,7 @@
     - lvnames
   when: >
         lvm['changed'] and
+        item[1]['filesystem'] is defined and
         item[1]['filesystem'] == "swap"
 
 - name: manage_lvm | resizing btrfs
@@ -109,13 +114,14 @@
     - lvnames
   when: >
         lvm['changed'] and
+        item[1]['filesystem'] is defined and
         item[1]['filesystem'] == "btrfs"
 
 - name: manage_lvm | unmounting filesystem(s)
   mount:
     name: "{{ item[1]['mntp'] }}"
     src: "/dev/{{ item[0]['vgname'] }}/{{ item[1]['lvname'] }}"
-    fstype: "{{ item[1]['filesystem'] }}"
+    fstype: "{{ item[1]['filesystem'] | default(omit) }}"
     state: "absent"
   become: true
   with_subelements:

--- a/tasks/manage_lvm.yml
+++ b/tasks/manage_lvm.yml
@@ -80,7 +80,8 @@
   when: >
         lvm['changed'] and
         item[1]['filesystem'] is defined and
-        item[1]['filesystem'] != "swap" and
+         item[1]['filesystem'] != "None" and
+         item[1]['filesystem'] != "swap" and
         item[1]['filesystem'] != "xfs" and
         item[1]['filesystem'] != "btrfs"
 


### PR DESCRIPTION
Logic to make the filesystem attribute optional, in situations where
we do not want the volumes formatted.

For example, when setting up LVM for Ceph Bluestore, we do not want the volumes formatted (and this would corrupt any existing Ceph configuration if rerun).