### PR TITLE
Check if XFS is mounted before performing xfs_info

### DIFF
--- a/tasks/create_fs.yml
+++ b/tasks/create_fs.yml
@@ -1,4 +1,11 @@
 ---
+# Check if the filesystem is already mounted 
+- name: "create_fs | check if fs mounted"
+  shell: "df {{ lv.mntp }} | grep {{ vg.vgname }} | grep {{ lv.lvname }} | wc -l"
+  become: yes
+  ignore_errors: true
+  changed_when: false
+  register: matchingmntp
 
 # unable to resize xfs: looks like we've to reference the mountpoint instead of the device
 - name: create_fs | check already converted
@@ -10,6 +17,8 @@
   ignore_errors: true
   changed_when: false
   when:
+    - matchingmntp is defined
+    - matchingmntp.stdout != "0"
     - lv is defined and lv != 'None'
     - lv.filesystem is defined
     - lv.filesystem == "xfs"
@@ -53,7 +62,7 @@
     dev: "/dev/{{ vg.vgname }}/{{ lv.lvname }}"
   become: true
   when:
-    - mountedxfs is failed
+    - mountedxfs is failed or matchingmntp.stdout == "0"
     - vg.create is defined
     - vg.create|bool
     - lv is defined


### PR DESCRIPTION
Check if the filesystem is mounted in order to allow xfs_info to be perfomed (Bugfix for #66)


## Description
XFS Filesystem were not created because of xfs_info returning info of the parent mountpoint

## Related Issue
https://github.com/mrlesmithjr/ansible-manage-lvm/issues/66

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)
