### PR TITLE
centos: Skip SCSI tasks on NVMe only hosts

### DIFF
--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -8,12 +8,6 @@
 - include_tasks: amazon.yml
   when: ansible_facts.system_vendor == 'Amazon EC2'
 
-- name: centos | installing sg3_utils
-  package:
-    name: sg3_utils
-    state: present
-  become: true
-
 - name: centos | debug lvg
   debug:
     var: lv
@@ -38,20 +32,36 @@
     - lv.1.create is defined
     - lv.1.create|bool
 
-- name: centos | checking for scsi devices
-  command: sg_scan
+- name: centos | check for scsi adapters
+  find:
+    paths: "/sys/class/scsi_host"
+    file_type: any
   become: true
-  register: scsi_devices
-  changed_when: false
+  register: scsi_adapters
 
-- name: centos | rescanning for new disks
-  command: /usr/bin/rescan-scsi-bus.sh
-  become: true
-  changed_when: false
-  when: scsi_devices.stdout|length > 0
+- block:
+  - name: centos | installing sg3_utils
+    package:
+    name: sg3_utils
+    state: present
+    become: true
 
-- name: centos | rescanning for resized disks
-  command: /usr/bin/rescan-scsi-bus.sh -s
-  become: true
-  changed_when: false
-  when: scsi_devices.stdout|length > 0
+  - name: centos | checking for scsi devices
+    command: sg_scan
+    become: true
+    register: scsi_devices
+    changed_when: false
+
+  - name: centos | rescanning for new disks
+    command: /usr/bin/rescan-scsi-bus.sh
+    become: true
+    changed_when: false
+    when: scsi_devices.stdout|length > 0
+
+  - name: centos | rescanning for resized disks
+    command: /usr/bin/rescan-scsi-bus.sh -s
+    become: true
+    changed_when: false
+    when: scsi_devices.stdout|length > 0
+
+  when: scsi_adapters.matched > 0


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
On NVMe only hosts - rescan-scsi-bus.sh fails

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/mrlesmithjr/ansible-manage-lvm/issues/74

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
