### PR TITLE
Fix syntax error on tasks/centos.yml

### DIFF
--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -44,8 +44,8 @@
 - block:
   - name: centos | installing sg3_utils
     package:
-    name: sg3_utils
-    state: present
+      name: sg3_utils
+      state: present
     become: true
 
   - name: centos | checking for scsi devices


### PR DESCRIPTION
## Description
Fix syntax error on tasks/centos.yml `package` attributes should be tabulated under `package` section.

## Related Issue
https://github.com/mrlesmithjr/ansible-manage-lvm/issues/80

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
