### PR TITLE
Add variable rescan_scsi_command

### DIFF
--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -55,13 +55,13 @@
     changed_when: false
 
   - name: centos | rescanning for new disks
-    command: /usr/bin/rescan-scsi-bus.sh
+    command: "{{ rescan_scsi_command }}"
     become: true
     changed_when: false
     when: scsi_devices.stdout|length > 0
 
   - name: centos | rescanning for resized disks
-    command: /usr/bin/rescan-scsi-bus.sh -s
+    command: "{{ rescan_scsi_command }} -s"
     become: true
     changed_when: false
     when: scsi_devices.stdout|length > 0

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -34,7 +34,7 @@
   changed_when: false
 
 - name: debian | rescanning for new disks added
-  command: /sbin/rescan-scsi-bus
+  command: "{{ rescan_scsi_command }}"
   become: true
   changed_when: false
   when: scsi_devices['stdout'] | length

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,12 @@
 ---
 # tasks file for ansible-manage-lvm
+- name: Set rescan_scsi_command for old debian version
+  set_fact:
+    rescan_scsi_command: "/sbin/rescan-scsi-bus"
+  when:
+    - ansible_distribution | replace(' ','') | lower == 'debian'
+    - ansible_distribution_major_version is version(10, '<=')
+
 - include_tasks: debian.yml
   when: ansible_facts.os_family == "Debian"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,3 +3,5 @@
 
 ebsnvme_binary_helper_file: go-ebsnvme_{{ ebsnvme_binary_helper_ver }}_linux_amd64.tar.gz
 ebsnvme_binary_helper_url:  https://github.com/mvisonneau/go-ebsnvme/releases/download/{{ ebsnvme_binary_helper_ver }}/{{ ebsnvme_binary_helper_file }}
+
+rescan_scsi_command: "/usr/bin/rescan-scsi-bus.sh"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Put the rescan scsi command into a variable because the path to this command is different on Debian older than 11

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fix #85 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
