### PR TITLE
fix for debian testing / sid

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
     rescan_scsi_command: "/sbin/rescan-scsi-bus"
   when:
     - ansible_distribution | replace(' ','') | lower == 'debian'
+    - ansible_distribution_release not in ('bookworm', 'sid')
     - ansible_distribution_major_version is version(10, '<=')
 
 - include_tasks: debian.yml


### PR DESCRIPTION
For Debian Testing and Sid `ansible_distribution_major_version` contains a string instead of an int

## Description
Change add an additional condition to check that the Debian distribution is newer than the latest stable version.

## Related Issue
[https://github.com/mrlesmithjr/ansible-manage-lvm/issues/90](https://github.com/mrlesmithjr/ansible-manage-lvm/issues/90)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
