### PR TITLE
Allow creating swap filesystems

### DIFF
--- a/tasks/create_fs.yml
+++ b/tasks/create_fs.yml
@@ -34,7 +34,7 @@
   filesystem:
     fstype: "{{ lv.filesystem }}"
     dev: "/dev/{{ vg.vgname }}/{{ lv.lvname }}"
-    resizefs: yes
+    resizefs: "{{ lv.filesystem != 'swap' }}"
   become: true
   when:
     - vg.create is defined
@@ -45,7 +45,6 @@
     - lv.create|bool
     - lv.filesystem is defined
     - lv.filesystem != 'None'
-    - lv.filesystem != 'swap'
     - lv.filesystem != 'xfs'
 
 - name: create_fs | creating new xfs filesystem on new LVM logical volume(s)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

The Ansible filesystem module does not support resizing swap
filesystems, and gives the following error when resizefs is true (which
was previously true by default):

  module does not support resizing swap filesystem yet.

In PR#89 this was worked around by skipping filesystem creation for swap
volumes. This isn't ideal however, because it prevents creation of
swapfs filesystems using this role, and will silently ignore requests to
create them.

This change fixes the issue by setting resizefs to false when
filesystem=swap.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes: #88

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
