### PR TITLE
Pass through opts to community.general.filesystem

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,8 @@ lvm_groups: []
 #       size: 40g
 #       create: true
 #       filesystem: ext4
+#       # Defines options passed to the filesystem creation command
+#       fsopts:
 #       mount: true
 #       mntp: /
 # - vgname: test-vg
@@ -57,6 +59,20 @@ lvm_groups: []
 #   lvnames:
 #   # Set to None to only create LVM VG w/out creating LVM LVOLS
 #    - None
+#   # Using fsopts to create a docker compatible xfs volume
+# - vgname: docker-volumes
+#   disks:
+#     - /dev/vdc
+#     - /dev/vdd
+#   create: true
+#   lvnames:
+#     - lvname: docker_1
+#       size: 100%FREE
+#       create: true
+#       filesystem: xfs
+#       fsopts: -n ftype=1
+#       mount: true
+#       mntp: /var/lib/docker
 
 # Defines if LVM will be managed by role
 # default is false to ensure nothing is changed by accident.

--- a/tasks/create_fs.yml
+++ b/tasks/create_fs.yml
@@ -52,6 +52,7 @@
   filesystem:
     fstype: "{{ lv.filesystem }}"
     dev: "/dev/{{ vg.vgname }}/{{ lv.lvname }}"
+    opts: "{{ lv.fsopts | default(omit) }}"
   become: true
   when:
     - mountedxfs is failed


### PR DESCRIPTION
Pass through opts to community.general.filesystem when creating a filesystem

## Description
Passes through the `fsopts` var to `opts` for the `community.general.filesystem` when creating a filesystm

## Types of changes
This change should not impact existing working usage as it just adds a new key to the configuration dictionary.

While most OS have `-n ftype=1` as a default, this allows it to be passed when creating a new `xfs` filesystem that's compatible with Docker. It's probably generally useful too.
