### PR TITLE
Pass options "fsopts" through when creating a filesystem

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,8 @@ lvm_groups: []
 #       size: 40g
 #       create: true
 #       filesystem: ext4
+#       # Defines options passed to the filesystem creation command
+#       fsopts:
 #       mount: true
 #       mntp: /
 # - vgname: test-vg
@@ -57,6 +59,20 @@ lvm_groups: []
 #   lvnames:
 #   # Set to None to only create LVM VG w/out creating LVM LVOLS
 #    - None
+#   # Using fsopts to create a docker compatible xfs volume
+# - vgname: docker-volumes
+#   disks:
+#     - /dev/vdc
+#     - /dev/vdd
+#   create: true
+#   lvnames:
+#     - lvname: docker_1
+#       size: 100%FREE
+#       create: true
+#       filesystem: xfs
+#       fsopts: -n ftype=1
+#       mount: true
+#       mntp: /var/lib/docker
 
 # Defines if LVM will be managed by role
 # default is false to ensure nothing is changed by accident.

--- a/tasks/create_fs.yml
+++ b/tasks/create_fs.yml
@@ -52,6 +52,7 @@
   filesystem:
     fstype: "{{ lv.filesystem }}"
     dev: "/dev/{{ vg.vgname }}/{{ lv.lvname }}"
+    opts: "{{ lv.fsopts | default(omit) }}"
   become: true
   when:
     - mountedxfs is failed


### PR DESCRIPTION
This change passes the `fsopts` option to the `filesystem` role called in this role allowing creating filesystems with options. 

## Description
Some things, like docker with xfs, require specific `fsopts` to be passed to the `filesystem` role that creates the filesystem in an LVM, this change allows that.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
