### PR TITLE
Add pvresize option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,8 @@ lvm_groups: []
 #   # defines if VG should exist or be removed
 #   # true or false
 #   create: true
+#   # defines if PV should be resized to max size
+#   pvresize: false
 #   lvnames:
 #     - lvname: swap_1
 #       # Define size of lvol
@@ -86,8 +88,5 @@ ebsnvme_binary_helper_path: '/sbin/go-ebsnvme'
 ###     nvme to scsi device name map script helper
 ebsnvme_scrip_helper_path: '/usr/local/bin/ebsnvme-id'
 
-###     auto pvresize (waiting until ansible 2.10 or above as collections have new lvg with integrated pvresize)
-###     waiting for new module in collection set to true or run pvresize manually on remote systems
-###     https://docs.ansible.com/ansible/3/collections/community/general/lvg_module.html
-###
+###   resize all pv's to max size
 pvresize_to_max: false

--- a/tasks/create_vg.yml
+++ b/tasks/create_vg.yml
@@ -4,23 +4,11 @@
     vg: "{{ vg.vgname }}"
     pvs: "{{ vg.disks | join(',') }}"
     state: present
+    pvresize: "{{ vg.pvresize | default(pvresize_to_max) }}"
   become: true
   when:
     - vg.create is defined
     - vg.create|bool
-
-### workaround: auto pvresize waiting for upgrade to new module supporting integrated pvresize
-###             ref: https://docs.ansible.com/ansible/3/collections/community/general/lvg_module.html
-- name: create_vg | pvresize to max available free space
-  ansible.builtin.command: "pvresize {{ pv }}"
-  loop: "{{ vg.disks | default([]) }}"
-  loop_control:
-    loop_var: pv
-  changed_when: false
-  when:
-    - vg.create is defined
-    - vg.create|bool
-    - pvresize_to_max|bool
 
 - name: manage_lvm | loop over logical volume group(s) to create logical volumes
   ansible.builtin.include_tasks: create_lv.yml


### PR DESCRIPTION
You can now define the pvresize per vg.

To avoid a breaking change, the global option pvresize_to_max is set as default

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
