### PR TITLE
use explicit boolean check

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -37,4 +37,4 @@
   ansible.builtin.command: "{{ rescan_scsi_command }}"
   become: true
   changed_when: false
-  when: scsi_devices['stdout'] | length
+  when: scsi_devices['stdout'] | length > 0


### PR DESCRIPTION
Change length check to return a bool

## Description
In Ansible verison 2.19, implicit truthy is no longer allowed.

Source: https://ansible.readthedocs.io/projects/ansible-core/devel/porting_guides/porting_guide_core_2.19.html#broken-conditionals

## Related Issue


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly. (No behaviour changes)
- [ ] I have added tests to cover my changes. (No tests needed)
- [x] All new and existing tests passed.
