### PR TITLE
fix conditional with ansible v12

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -37,4 +37,4 @@
   ansible.builtin.command: "{{ rescan_scsi_command }}"
   become: true
   changed_when: false
-  when: scsi_devices['stdout'] | length
+  when: scsi_devices.stdout | length > 0


### PR DESCRIPTION
this pr fixes an error with ansible v12

```bash
                                                                                                                                                                                           TASK [mrlesmithjr.manage_lvm : debian | rescanning for new disks added]
************************************************ 
[ERROR]: Task failed: Conditional result (True) was derived from value of type 'int' at '/home/ansible-dev/.ansible/roles/mrlesmithjr.manage_lvm/tasks/debian.yml:40:9'. 
Conditionals must have a boolean result.  
Task failed.  
Origin: /home/ansible-dev/.ansible/roles/mrlesmithjr.manage_lvm/tasks/debian.yml:36:3      
34   changed_when: false  
35   
36 - name: debian | rescanning for new disks added  
^ column 3    
<<< caused by >>>  
Conditional result (True) was derived from value of type 'int' at '/home/ansible-dev/.ansible/roles
mrlesmithjr.manage_lvm/tasks/debian.yml:40:9'. Conditionals must have a boolean result.Origin: /home
ansible-dev/.ansible/roles/mrlesmithjr.manage_lvm/tasks/debian.yml:40:9                                                                                                                                                                                                                                                                                                
38   become: true                                                                                                                                                                         
39   changed_when: false                                                                                                                                                                  
40   when: scsi_devices['stdout'] | length                                                                                                                                                           
^ column 9                                                                                                                                                                                                                                                                                                                                                                
Broken conditionals can be temporarily allowed with the `ALLOW_BROKEN_CONDITIONALS` configuration
option.                                                                                                                                                                                                                                                                            
fatal: [munin.mgrote.net]: FAILED! => {"changed": false, "msg": "Task failed: Conditional result (True)
was derived from value of type 'int' at '/home/ansible-dev/.ansible/roles/mrlesmithjr.manage_lvm/tasks
debian.yml:40:9'. Conditionals must have a boolean result."}                                                                                                          
fatal: [docker10.mgrote.net]: FAILED! => {"changed": false, "msg": "Task failed: Conditional result
(True) was derived from value of type 'int' at '/home/ansible-dev/.ansible/roles/mrlesmithjr.manage_lvm
tasks/debian.yml:40:9'. Conditionals must have a boolean result."}                                                                                                       
fatal: [forgejo.mgrote.net]: FAILED! => {"changed": false, "msg": "Task failed: Conditional result
(True) was derived from value of type 'int' at '/home/ansible-dev/.ansible/roles/mrlesmithjr.manage_lvm
tasks/debian.yml:40:9'. Conditionals must have a boolean result."}                                      
```